### PR TITLE
Live Data Pull

### DIFF
--- a/server/data/parkinfo/ARNOVACE.html
+++ b/server/data/parkinfo/ARNOVACE.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Arnos Vale Cemetery</title>
+</head>
+<body>
+    <h1>Arnos Vale Cemetery</h1>
+    <p>Victorian cemetery with green space, listed buildings and monuments.</p>
+    <h2>Admission and opening times</h2>
+    <p>There is no charge for admission. For opening times <a href="https://arnosvale.org.uk/discover/site-info/">see the Arnos Vale website</a>.</p>
+    <h2>Location</h2>
+    <p>Arnos Vale Cemetery, Bath Road, Bristol, BS4 3EW</p>
+    <h2>Parking</h2>
+    <p>There is limited parking. Contact Arnos Vale on 0117 971 9117 for more information.</p>
+    <h2>Disabled access</h2>
+    <p>Find out about <a href="https://arnosvale.org.uk/discover/site-info/" target="_blank">disabled access and parking at the Arnos Vale website</a>. You can also look at <a href="http://www.disabledgo.com/access-guide/bristol-city-council/arnos-vale">an access guide at DisabledGo</a>.</p>
+    <h2>Facilities and features</h2>
+    <ul>
+    <li>café: check <a href="https://arnosvale.org.uk/atrium-cafe">café opening hours at the Arnos Vale website</a></li>
+    <li>Anglican Chapel</li>
+    <li>public toilets at the Spielman Centre (non-conformist Chapel)</li>
+    <li><a href="http://arnosvale.org.uk/books-of-remembrance">Books of Remembrance</a></li>
+    <li>exhibitions in the West Lodge</li>
+    <li>gift shop in the East Lodge</li>
+    </ul>
+    <h2>Activities</h2>
+    <ul>
+    <li>self-guided tours: <a href="https://arnosvale.org.uk/discover/" target="_blank">order trail leaflets from the Arnos Vale website</a></li>
+    <li><a href="http://arnosvale.org.uk/learning">educational programmes</a> ranging from primary school level to adult learners</li>
+    <li>fitness sessions: <a href="https://arnosvale.org.uk/event-category/fitness-and-dance/" target="_blank">find out what classes are running at the Arnos Vale website</a></li>
+    </ul>
+    <h2>Events</h2>
+    <p>Arnos Vale Cemetery Trust holds events throughout the year. See <a href="http://arnosvale.org.uk/events">what’s on at the Arnos Vale website</a>.</p>
+    <h2>Awards and heritage</h2>
+    <ul>
+    <li>The Landscape Institute’s 2010 Heritage and Conservation Award</li>
+    <li>Grade II* listed Mortuary Chapels and Grade II listed grave structures</li>
+    <li><a href="http://www.socialenterprisemark.org.uk/what-is-the-social-enterprise-mark/">Social Enterprise Mark</a> holder</li>
+    <li>RIBA South West Town and Country Design Conservation Award 2010</li>
+    <li>Bristol Civic Society Environmental Award 2010</li>
+    <li>English Heritage Angel Award 2011</li>
+    </ul>
+</body>
+</html>

--- a/server/data/parkinfo/ASHTCOES.html
+++ b/server/data/parkinfo/ASHTCOES.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Ashton Court Estate</title>
+</head>
+<body>
+  <h1>Ashton Court Estate</h1>
+  <p>Country park and mansion with 850 acres of woodland and grassland and many activities.</p>
+    <h2>Admission and opening times</h2>
+    <p>There is normally no charge for admission. You may have to pay for entry to some parts of the estate if a special event is running at Ashton Court.&nbsp;</p>
+    <p>The estate is open Monday to Sunday from 8am. Closing times are different throughout the year:</p>
+    <ul>
+    <li>5.15pm in November, December and January</li>
+    <li>6.15pm in February</li>
+    <li>7.15pm in March</li>
+    <li>8.15pm in April</li>
+    <li>9.15pm in May, June, July and August</li>
+    <li>8.15pm in September</li>
+    <li>7.15pm in October</li>
+    </ul>
+    <p>Ashton Court Estate is open over the Christmas period but check the dates for car parks and cafes.&nbsp;</p>
+    <p>To report a problem at Ashton Court visit our <a href="https://www.bristol.gov.uk/museums-parks-sports-culture/report-problem-in-park" target="">report a problem in a park page</a>.</p>
+    <h2>Location</h2>
+    <p>Ashton Court Estate, Long Ashton, Bristol, BS41 9JN</p>
+
+    <h2>Parking</h2>
+    <p>There are three car parks in Ashton Court. The car parks open at 8am.</p>
+    <p>Parking costs £1.20 per vehicle per day. You can use your parking ticket in any of the Ashton Court car parks for that day. You can also return during the same day without paying again.</p>
+    <p>There is no parking charge for Blue Badge holders, motorcycles and scooters.</p>
+    <p>Open every day including Christmas.</p>
+    <h3>When charges apply:</h3>
+    <ul>
+    <li>Church Lodge car park (Dovecote): from 10am</li>
+    <li>Mansion House car park: from 9am</li>
+    <li>Clifton Lodge car park (Golf): from 6am</li>
+    </ul>
+    <p>Charges apply until the estate closes. Closing times vary throughout the year.</p>
+    <h2>Disabled access</h2>
+    <p>There are two disabled toilets in the stables courtyard.</p>
+    <p>If you use a wheelchair, have restricted mobility or are visually impaired, it may be difficult to get around the estate due to the terrain and topography.</p>
+    <p>The stables courtyard is level but has a cobbled surface.</p>
+    <p>There is limited wheelchair access to the formal gardens.</p>
+    <p>Find out about <a href="http://www.disabledgo.com/access-guide/bristol-city-council/ashton-court-mansion---courtyard-cafe">the courtyard cafe's accessibility on DisabledGo</a>.</p>
+    <h3>Parking</h3>
+    <ul>
+    <li>Mansion House car park: 10 disabled parking bays</li>
+    <li>Clifton Lodge car park (Golf): one disabled parking bay</li>
+    <li>Church Lodge car park (Dovecote): 10 disabled parking bays</li>
+    </ul>
+    <h2>Ashton Court Mansion</h2>
+    <p>The mansion is open from 11am to 4pm, Wednesdays&nbsp;to Sundays.&nbsp;</p>
+    <p>It is now run by Artspace Lifespace, a registered charity.</p>
+    <p>You can find out more on the <a href="http://artspacelifespace.com/current-projects/arts-mansion/">Artspace Lifespace website.</a>&nbsp;</p>
+    <h2>Facilities and features</h2>
+    <ul>
+    <li>courtyard café (<a href="/documents/20182/34344/Ashton+Court+Estate+Courtyard+Cafe+Menu.pdf/d0880a02-3e6c-ad6b-39c2-77083d10c1da" target="_blank">menu<span class="auto-generated-accessibly-text"> (pdf, 79KB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> )</li>
+    <li>golf course café</li>
+    <li>toilets with baby changing facilities (access via the stables courtyard)</li>
+    <li>woodland garden</li>
+    <li>picnic area</li>
+    <li>deer parks</li>
+    <li><a href="/c/portal/layout?p_l_id=24227">golf course</a></li>
+    </ul>
+    <h2>Activities</h2>
+    <ul>
+    <li>ballooning: the annual <a href="http://www.bristolballoonfiesta.co.uk/">Bristol International Balloon Fiesta</a> is held at Ashton Court Estate</li>
+    <li><a href="https://www.bristol.gov.uk/museums-parks-sports-culture/ashton-court-golf-course" target="">Golf,&nbsp;FootGolf and Disc Golf</a></li>
+    <li>miniature railway: check the <a href="http://www.bristolmodelengineers.co.uk/public-running-days/">Bristol Model Engineers website</a> for prices and opening times</li>
+    <li><a href="/c/portal/layout?p_l_id=465529">mountain biking</a></li>
+    <li>parkrun: a free 5km run every Saturday; <a href="http://www.parkrun.org.uk/ashton-court/">register at the Parkrun website</a></li>
+    </ul>
+    <h3>Flying model aircraft, including drones</h3>
+    <p>Model aircraft, including drones, can't be flown on the Ashton Court Estate. However, you can fly them in parts of:</p>
+    <ul>
+    <li><a href="/c/portal/layout?p_l_id=23705">Hengrove Park</a></li>
+    <li><a href="/c/portal/layout?p_l_id=1692491">Dundridge Park</a></li>
+    <li><a href="/c/portal/layout?p_l_id=23624">Blaise Castle Estate</a></li>
+    </ul>
+    <h2>Courtyard café</h2>
+    <p>Address: The Stables Courtyard, Ashton Court Estate, Long Ashton, Bristol, BS41 9JN.</p>
+    <p>Serves a selection of hot and cold food, ice creams and snacks. &nbsp;</p>
+    <p>Indoor and outdoor seating is available. Toilets available.</p>
+    <h3>Opening times</h3>
+    <p>Monday to Sunday, 9.30am&nbsp;to 3.30pm&nbsp;</p>
+    <p>Opening times may change depending on the weather.</p>
+    <p>Call:&nbsp;0117 963 9176<span><span><span> </span></span></span></p>
+    <h2>Golf café</h2>
+    <p>Address: Ashton Court Golf and Cycle Centre, Ashton Court Estate, Long Ashton, Bristol, BS8 3PX</p>
+    <p>Serves a selection of hot and cold food, ice creams and snacks. &nbsp;</p>
+    <p>Both indoor and outdoor seating is available. Toilets available.&nbsp;</p>
+    <h3>Opening&nbsp;times</h3>
+    <p>Monday to Sunday, 10am&nbsp;to 3pm</p>
+    <p>Opening times may change depending on the weather.</p>
+    <p>Call: 0788 0042 613</p>
+</body>
+</html>

--- a/server/data/parkinfo/BEGBGRPA.html
+++ b/server/data/parkinfo/BEGBGRPA.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Begbrook Green Park</title>
+</head>
+<body>
+  <h1>Begbrook Green Park</h1>
+  <p>Modern community park with children’s play areas and sports pitches.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. Begbrook Green Park is open at all times.</p>
+  <h2>Location</h2>
+  <p>Begbrook Green Park, Frenchay Park Road, Bristol, BS16 1JG</p>
+  <h2>Parking</h2>
+  <p>There is a small car park at the main entrance on Frenchay Park Road.</p>
+  <h2>Disabled access</h2>
+  <p>This park is wheelchair accessible.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>toddler play area with climbing frame, cargo net, slide, swings and nest swing</li>
+  <li>rock climbing wall with cargo net for older children</li>
+  <li>playgrounds are fenced off and dog free</li>
+  <li>four <a href="/c/portal/layout?p_l_id=216028">outdoor exercise stations</a></li>
+  <li><a href="/c/portal/layout?p_l_id=24236">bowling green</a></li>
+  <li><a href="/c/portal/layout?p_l_id=24272">football pitches</a></li>
+  <li><a href="/c/portal/layout?p_l_id=24236">all weather pitches</a></li>
+  <li>changing rooms for the sports pitches</li>
+  </ul>
+</body>
+</html>

--- a/server/data/parkinfo/BLAICAES.html
+++ b/server/data/parkinfo/BLAICAES.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Blaise Castle Estate</title>
+</head>
+<body>
+  <h1>Blaise Castle Estate</h1>
+  <p>A 650 acre Grade II* registered parkland including children’s play area, museum and castle.</p>
+  <h2>Admission and opening times</h2>
+  <p>Admission is free. Access may be restricted on major event days.</p>
+  <p>Blaise Castle Estate is open every day from 7.30am. Closing times vary throughout the year:</p>
+  <ul>
+  <li>5.15pm in November, December and January</li>
+  <li>6.15pm in February</li>
+  <li>7.15pm in March</li>
+  <li>8.15pm in April</li>
+  <li>9.15pm in May, June, July and August</li>
+  <li>8.15pm in September</li>
+  <li>7.15pm in October</li>
+  </ul>
+  <p>To find out when the dairy garden and castle are open, see noticeboards at the estate.</p>
+  <h2>Location</h2>
+  <p>Blaise Castle Estate, Kings Weston Road, Lawrence Weston, Bristol, BS10 7QS</p>
+  <h2>Parking</h2>
+  <p>There are two car parks:</p>
+  <ul>
+  <li>main car park off Kings Weston Road at BS10 7QS</li>
+  <li>small car park off The Dingle at BS9 2PA</li>
+  </ul>
+  <p>The car parks close at the same time as the estate.</p>
+  <p>Car parks are closed on 25 December.</p>
+  <p>There is no charge for parking.</p>
+  <h2>Disabled access</h2>
+  <p>You can find <a href="http://www.disabledgo.com/access-guide/bristol-city-council/blaise-castle-house-museum">an access guide on the DisabledGo website</a>.</p>
+  <h3>Parking</h3>
+  <ul>
+  <li>main car park: five disabled parking bays</li>
+  <li>small car park: one disabled parking bay</li>
+  </ul>
+  <p>The entrance to the estate from the small car park is through a kissing gate that's not accessible to wheelchairs or mobility scooters.</p>
+  <p>If you use a wheelchair or mobility scooter you can access the site from the main car park at Kings Weston Road.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li><a href="http://www.bristolmuseums.org.uk/blaise-castle-house-museum/">Blaise Castle House Museum</a></li>
+  <li><a href="http://www.nationaltrust.org.uk/blaise-hamlet/">Blaise Hamlet</a> (National Trust property)</li>
+  <li><a href="https://www.friendsofblaise.co.uk/castle.html">Blaise Castle</a></li>
+  <li><a href="https://www.bristol.gov.uk/museums-parks-sports-culture/blaise-plant-nursery" target="_blank">Blaise Plant Nursery</a></li>
+  <li><a href="https://www.bristolmuseums.org.uk/blaise-castle-house-museum/whats-at/the-dairy-and-gardens/" target="">Dairy and gardens</a></li>
+  <li>café</li>
+  <li>children’s play area with areas for younger and older children</li>
+  <li>toilets with baby changing facilities: toilets closed on 25 December</li>
+  <li>benches and picnic areas</li>
+  <li>BBQs are allowed as long as you raise them off the ground</li>
+  <li>one <a href="/c/portal/layout?p_l_id=24236">cricket pitch</a></li>
+  <li>grassed space for play and sport</li>
+  <li>lily pond</li>
+  </ul>
+  <h2>Activities</h2>
+  <ul>
+  <li>horse riding,&nbsp;a two mile trail runs from Kings Weston Road car park to Kings Weston Down</li>
+  <li>orienteering,&nbsp;the course is managed by <a href="http://www.bristolorienteering.org.uk/permanent-courses/blaise-castle">Bristol Orienteering Klub</a></li>
+  <li>Nordic walking,&nbsp;sessions are run by <a href="http://www.bristolnordicwalking.co.uk/">Bristol Nordic Walking</a></li>
+  <li>buggy-friendly walking,&nbsp;<a href="http://www.walkswithbuggies.com/UK/Bristol/Bristol/881">Walks With Buggies has an accessible walking route</a></li>
+  </ul>
+  <h3>Model aircraft, including drones</h3>
+  <p>Under the <a href="/c/portal/layout?p_l_id=1629977">park byelaws</a>, you can fly model aircraft, including drones, in <a href="/documents/20182/32823/Model+aircraft+Blaise/e04f0e6a-b93d-8b7f-0bb6-04909d476c90" target="_blank">part of the Blaise Estate<span class="auto-generated-accessibly-text"> (pdf, 680KB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> .</p>
+  <p>It must weigh 7kg or less, without its fuel. The person flying the aircraft must be a member of the British Model Flying Association and have public liability insurance.</p>
+  <h2 style="margin-top: 40px; color: rgb(46, 49, 55);">Blaise Castle Estate café</h2>
+  <p>Address: Blaise Castle Estate, Kings Weston Road, Bristol, BS10 7QS</p>
+  <p>The café serves sandwiches, snacks, ice creams and drinks.&nbsp;Both indoor and outdoor seating is available. There are toilets including a disabled toilet block and baby changing facilities.</p>
+  <p>There are cycle racks outside the café.</p>
+  <h3 style="color: rgb(46, 49, 55);">Opening times</h3>
+  <p>October to March: Monday to Sunday, 9am to 2.30pm</p>
+  <p>April to September: Monday to Sunday, 9am to 5pm</p>
+  <p>Bank Holiday opening times: 10am to 2pm</p>
+  <p>Opening times may change depending on the weather.</p>
+  <h2>Walking routes</h2>
+  <p>There are footpaths in the estate. You can download maps of our walking routes:</p>
+  <h3>Castle walk</h3>
+  <p>1¼ miles (40 minutes)</p>
+  <p>Has views over the gorge. Woodland trails with some steep inclines that can be muddy.</p>
+  <p><a href="/documents/20182/34296/Castle+Walk+FINAL+NEW.pdf/9c83c0c1-46d9-46bb-8795-677bf3a5bb7f" target="_blank">Blaise Estate castle walk leaflet<span class="auto-generated-accessibly-text"> (pdf, 758KB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  <h3>Gorge walk</h3>
+  <p>1½ miles (50 minutes)</p>
+  <p>Has views of the gorge and surrounding woodland. This walk uses surfaced and woodland paths. There are steep inclines.</p>
+  <p><a href="/documents/20182/34296/Blaise+Castle+Gorge+walk/0d100611-85b2-44a5-a062-425518a8a992" target="_blank">Blaise Estate gorge walk leaflet<span class="auto-generated-accessibly-text"> (pdf, 772KB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  <h3>Kings Weston Down walk</h3>
+  <p>1½ miles (35 minutes)</p>
+  <p>Includes woodland paths, grassland and the Iron Age hill fort.</p>
+  <p><a href="/documents/20182/34296/Kings+Weston+Down+walk/3f5f50c1-5650-461e-9910-ab3ce6f688ca" target="_blank">Blaise Estate Kings Weston Down walk leaflet<span class="auto-generated-accessibly-text"> (pdf, 731KB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  <h3>Rhododendron walk</h3>
+  <p>3 miles (1 hour and 45 minutes)</p>
+  <p>Includes many of the estates natural features and historical buildings. This walk uses surfaced paths and woodland trails on mixture of terrains. Includes steep inclines.</p>
+  <p><a href="/documents/20182/292038/Rhododendron+walk+FINAL+NEW.pdf/e61bfdb2-2815-4581-8f39-4ffb6be99c56" target="_blank">Blaise Estate Rhododendron walk leaflet<span class="auto-generated-accessibly-text"> (pdf, 752KB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  <h3>The Royals and St Mary's Church walk</h3>
+  <p>1¼ miles (50&nbsp;minutes)</p>
+  <p>Includes The Royals and St Mary's Church Yard. This walk uses woodland trails, grass and surfaced paths. The main drive is suitable for buggies.</p>
+  <p><a href="/documents/20182/292038/Royals+and+St+Marys+walk+FINAL+NEW.pdf/c801a16e-8bad-4f35-831f-159f4bbb08b3" target="_blank">Blaise Estate The Royals and St Mary's Church walk leaflet<span class="auto-generated-accessibly-text"> (pdf, 761KB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  <h2>Awards and heritage</h2>
+  <p>Site of special scientific interest: protected area of importance for conservation.</p>
+  <h2>Community support</h2>
+  <p>The Friends of Blaise is a community group that works in cooperation with the Council to maintain and improve the Estate. For more information and their activities or to join, e-mail them at <a href="mailto:contact@friendsofblaise.co.uk">contact@friendsofblaise.co.uk.</a></p>
+</body>
+</html>

--- a/server/data/parkinfo/BRANHIPA.html
+++ b/server/data/parkinfo/BRANHIPA.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Brandon Hill</title>
+</head>
+<body>
+  <h1>Brandon Hill</h1>
+  <p>Hilly park and popular picnic spot with nature reserve and views from Cabot Tower.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission.</p>
+  <p>Brandon Hill is open at all times.</p>
+  <h2>Cabot Tower opening times</h2>
+  <p>Monday to Sunday: 8:15am to 6.15pm</p>
+  <p>Closed: 25 and 26 December and 1 January</p>
+  <h2>Location</h2>
+  <p>Brandon Hill Park, Park St, Bristol, Avon BS1 5RR</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Disabled access</h2>
+  <p>You can find <a href="http://www.disabledgo.com/access-guide/bristol-city-council/brandon-hill-nature-park">an access guide on the DisabledGo website</a>.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>dog-free <a href="http://www.goplacestoplay.org.uk/pathfinder_sites/11-brandon-hill-park">play area</a> for under 12s</li>
+  <li>Cabot Tower</li>
+  <li><a href="http://www.avonwildlifetrust.org.uk/reserves/brandon-hill-nature-park">Brandon Hill Nature Park</a></li>
+  <li>toilets close to Cabot Tower</li>
+  <li>two <a href="/c/portal/layout?p_l_id=216028">outdoor exercise stations</a></li>
+  </ul>
+  <h3>Toilets close to Cabot Tower opening times</h3>
+  <p>Monday to Sunday: 8:15am to 6:15pm</p>
+  <p>Closed: 25 and 26&nbsp;December and 1&nbsp;January.</p>
+  <h2>Barbeques (BBQs)</h2>
+  <p>You can only have a barbeque in certain parts of <a href="/documents/20182/32823/Brandon+Hill+BBQs/b194d1d7-a548-f2f4-831b-df7a75133873" target="_blank">Brandon Hill (map)<span class="auto-generated-accessibly-text"> (pdf, 332KB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> . You must not have the BBQ in a children's play area and the BBQ must be:</p>
+  <ul>
+  <li>shop bought, not home-made</li>
+  <li>placed on the ground, not on park furniture</li>
+  <li>on legs, so the grass isn't burnt</li>
+  <li>watched when lit</li>
+  <li>cold before it's put in a rubbish bin</li>
+  </ul>
+  <p>You must put all litter in a rubbish bin or take it home with you.</p>
+  <p>Open fires aren't allowed.</p>
+  <h2>Community support</h2>
+  <p>The Friends of Brandon Hill is a community group that supports the park. For more information on joining the group visit <a href="https://www.facebook.com/brandonhillbristol/" target="_blank">The Friends of Brandon Hill Facebook page</a>.</p>
+  <h2>Activities</h2>
+  <ul>
+  <li>Tree Trail developed by <a href="http://www.bristolparksforum.org.uk/brandonhill/">Friends of Brandon Hill</a></li>
+  <li>Tai Chi run by <a href="http://www.bristoltaichi.com/taichipark.htm">Bristol School of Tai Chi</a></li>
+  </ul>
+  <h2>Awards and heritage</h2>
+  <p>Parts of the park are <a href="https://www.historicengland.org.uk/advice/planning/consents/smc">scheduled ancient monuments</a>.</p>
+
+</body>
+</html>

--- a/server/data/parkinfo/CANFPAANCP.html
+++ b/server/data/parkinfo/CANFPAANCP.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Canford Park</title>
+</head>
+<body>
+  <h1>Canford Park</h1>
+  <p>Victorian park with children’s play park, bowling green, tennis courts and football pitches.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. Canford Park is open at all times.</p>
+  <h2>Location</h2>
+  <p>Canford Park, Canford Lane, Westbury-on-Trym, BS9 3NX</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Disabled access</h2>
+  <p>Entrances are wide enough for wheelchairs. The park is flat with many paths. There are steps to access the pond and sunken rose garden.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>adventure play park</li>
+  <li><a href="/c/portal/layout?p_l_id=24236">bowling green</a> and pavilion</li>
+  <li>eight tennis courts: free for casual use, no booking needed</li>
+  <li>two <a href="/c/portal/layout?p_l_id=24236">football pitches</a> (bookable on Saturdays)</li>
+  <li>café kiosk</li>
+  <li>outdoor seating</li>
+  <li>public toilet</li>
+  <li>drinking fountain (Grade II listed)</li>
+  <li>sunken garden and lily pond</li>
+  <li>measured route: marked 600m route for walking, jogging or running</li>
+  </ul>
+  <h3>Toilet opening times</h3>
+  <p>Open 7 days a week: 10am to 5pm.</p>
+  <h3>Café Kiosk</h3>
+  <p>Address: Canford Lane, Westbury-on-Trym, Bristol BS9 3NX</p>
+  <p>Next to the adventure play park.</p>
+  <h4>Opening times</h4>
+  <ul>
+  <li>October to March: Saturday and Sunday, 9am to 2pm</li>
+  <li>April to September: Wednesday to Sunday, 9am to 5pm</li>
+  </ul>
+  <p>Opening times may change depending on the weather.</p>
+</body>
+</html>

--- a/server/data/parkinfo/CASTPA.html
+++ b/server/data/parkinfo/CASTPA.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Castle Park</title>
+</head>
+<body>
+  <h1>Castle Park</h1>
+  <p>Large green space in the city centre.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. Castle Park is open at all times.</p>
+  <h2>Location</h2>
+  <p>Castle Park, Broad Weir, Bristol, BS1 3XB.</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. You can park in <a href="http://www.galleriesbristol.co.uk/centre-information/parking.html">the Galleries car park</a>, which is opposite Castle Park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Disabled access</h2>
+  <p>There are steps in some areas of Castle Park.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>remains of Bristol Castle’s keep, walls and vaults (Grade II listed)</li>
+  <li>bandstand used for events and music sessions</li>
+  <li>St Peter’s Church (Grade II* listed)</li>
+  <li>physic garden for growing medicinal plants, maintained by <a href="http://www.google.co.uk/aclk?sa=l&amp;ai=CI30tdZASVrubCYW3hASPjZiAAa6p6vsD1p_7wIoBspCZrA4IABABYLvGmoPQCqAB0suJ0QPIAQGqBChP0KstZZDDa5Fdyp1PqKylma5Fzka314sPQaOrlkepi91V6X-9AZ8pgAeWtPYuiAcBkAcCqAemvhvYBwE&amp;sig=AOD64_0CtgnSb_pI5IyfgZQJ8gh6QzSuCA&amp;clui=0&amp;rct=j&amp;q=&amp;ved=0CCAQ0QxqFQoTCJ2T-aXMq8gCFUjQgAod6N8JLg&amp;adurl=http://www.mungosbroadway.org.uk/how_you_can_help/make_a_donation">St Mungo’s Broadway</a></li>
+  <li>seven Silver Birch trees in memory of the seven beaches of the D-Day landings</li>
+  </ul>
+  <h2>Castle Park Tree Trail</h2>
+  <p>See our new <a href="/documents/20182/32911/Castle+park+tree+trail+leaflet/b0adb67a-d491-b8f0-e510-221dd2bfe160" target="_blank">tree trail leaflet<span class="auto-generated-accessibly-text"> (pdf, 8.1MB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> to help you explore and learn about Castle Park.</p>
+  <h2>Heritage</h2>
+  <p>Parts of the park are <a href="https://www.historicengland.org.uk/advice/planning/consents/smc">scheduled ancient monuments</a>.</p>
+  <p>There are a series of interpretation panels in Castle Park that trace the history of this area of the city and which explain the archaeological remains above and below ground.</p>
+  <p>Please see the <a href="http://www.locallearning.org.uk/castle-park/">Local Learning website</a> for further information about the history and development of Castle Park.</p>
+</body>
+</html>

--- a/server/data/parkinfo/COLLGR.html
+++ b/server/data/parkinfo/COLLGR.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>College Green</title>
+</head>
+<body>
+  <h1>College Green</h1>
+  <p>Peaceful city centre green space near to local attractions.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. College Green is open at all times.</p>
+  <h2>Location</h2>
+  <p>College Green, Bristol, BS1 5UY</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Disabled access</h2>
+  <p>College Green has wheelchair accessible pathways.</p>
+  <p>There is an accessible toilet in the nearby <a href="https://www.bristol.gov.uk/libraries-archives/library-finder/-/journal_content/56/20195/LIBRARY-UPRN-000000199356/LIBRARY-DISPLAY">Central Library</a>.</p>
+  <h2>Facilities and features</h2>
+  <p>Public toilets are in the nearby <a href="https://www.bristol.gov.uk/libraries-archives/library-finder/-/journal_content/56/20195/LIBRARY-UPRN-000000199356/LIBRARY-DISPLAY">Central Library</a>.</p>
+</body>
+</html>

--- a/server/data/parkinfo/COTHGA.html
+++ b/server/data/parkinfo/COTHGA.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Cotham Gardens</title>
+</head>
+<body>
+  <h1>Cotham Gardens</h1>
+  <p>Small Victorian park in a suburb of north Bristol.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. Cotham Gardens is open at all times.</p>
+  <h2>Location</h2>
+  <p>Redland Grove, Redland, Bristol BS6 6AG</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Disabled access</h2>
+  <p>Cotham Gardens is accessible, but there are some gentle slopes.</p>
+  <h2>Facilities and features</h2>
+  <p>There is a large dog-free play area for under 12s.</p>
+  <h2>Community support</h2>
+  <p>The Redland &amp; Cotham Amenities Society is a community group that supports the park. For more information or to join visit the <a href="http://www.rcas.org.uk/">Redland &amp; Cotham Amenities Society website</a>.</p>
+</body>
+</html>

--- a/server/data/parkinfo/DAMEEMPA.html
+++ b/server/data/parkinfo/DAMEEMPA.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Dame Emily Park</title>
+</head>
+<body>
+  <h1>Dame Emily Park</h1>
+  <p>Community park in the middle of Bedminster with children’s park, skate park and green space.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. Dame Emily Park is open at all times.</p>
+  <h2>Location</h2>
+  <p>Dame Emily Park, Dean Lane, Bedminster, BS3 1BS</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Disabled access</h2>
+  <p>Dame Emily Park is accessible, but there are some gentle slopes.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>dog-free playground for under 10s with a zip-wire for older children</li>
+  <li>wheels park for BMX, skateboards and scooters</li>
+  <li>basketball court</li>
+  <li>community garden (managed by <a href="https://www.facebook.com/Dame-Emily-Park-169685766421986/">Dame Emily Park Project</a>)</li>
+  </ul>
+  <h2>Community support</h2>
+  <p>The Dame Emily Park Project was started by local people to support the park. For more information or to join visit the <a href="https://www.facebook.com/Dame-Emily-Park-169685766421986/">Dame Emily Park Facebook page</a>.</p>
+</body>
+</html>

--- a/server/data/parkinfo/DEFAULT.html
+++ b/server/data/parkinfo/DEFAULT.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Park Info</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/server/data/parkinfo/DUNDFAPLFI.html
+++ b/server/data/parkinfo/DUNDFAPLFI.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Dundridge Park</title>
+</head>
+
+<body>
+  <h1>Dundridge Park</h1>
+  <p>Large community park in St George with children’s playground and football pitches.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. Dundridge Park is open at all times.</p>
+  <h2>Location</h2>
+  <p>Dundridge Lane, Bristol, BS5 8SW<br />
+  <h2>Parking</h2>
+  <p>Dedicated car park is open 7 days a week&nbsp;</p>
+  <h2>Disabled access</h2>
+  <p>The entrance gate is wide enough for most disability scooters. &nbsp;There is a level path along one side of the park and to the children’s play area.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+    <li>two <a href="/c/portal/layout?p_l_id=24236">football pitches</a> (bookable on Saturdays and Sundays)</li>
+    <li>artificial cricket pitch</li>
+    <li>outdoor seating</li>
+    <li>children’s play area</li>
+    <li>woodland areas</li>
+    <li>bridleway</li>
+  </ul>
+  <h2>Model aircraft, including drones</h2>
+  <p>Under the <a href="/c/portal/layout?p_l_id=1629977">park byelaws</a>,&nbsp;you can fly model aircraft, including drones, in <a href="/documents/20182/32823/Model+aircraft+Dundridge+Park/bb841e0e-9515-d226-90b2-f8b9101d9b9c" target="_blank">part
+      of Dundridge Park<span class="auto-generated-accessibly-text"> (pdf, 140k) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> .</p>
+  <p>The model aircraft must weigh 7kg or less, without its fuel. The person flying the aircraft must be a member of the British Model Flying Association and have public liability insurance.</p>
+</body>
+
+</html>

--- a/server/data/parkinfo/DURDDO.html
+++ b/server/data/parkinfo/DURDDO.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>The Downs</title>
+</head>
+<body>
+  <h1>The Downs</h1>
+  <p class="lead">Large green spaces on the edge of the city suitable for picnics, exercise, sport and events.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. The Downs is open at all times. Access may be restricted for special events.</p>
+  <h2>Location</h2>
+  <p>Clifton Down and Durdham Down are north of the city centre.&nbsp;</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Disabled access</h2>
+  <p>To find out about accessibility at The Downs, you can look at <a href="http://www.disabledgo.com/access-guide/bristol-city-council/downs">an access guide on DisabledGo</a>.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li><a href="http://www.caferetreat.co.uk/">Café Retreat</a></li>
+  <li>toilets and baby changing facilities at Sea Walls (on Circular Road)</li>
+  <li>urinals at Blackboy Hill</li>
+  <li>benches and picnic areas</li>
+  <li>children’s playground on Sion Hill</li>
+  <li><a href="/documents/20182/32863/BBQ%20locations%20at%20Ladies%20Mile%20on%20The%20Downs.pdf/8f60f08f-332d-4fa3-bd16-7cbc19fdecd4" target="_blank">BBQ area on Ladies Mile<span class="auto-generated-accessibly-text"> (pdf, 3.8MB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> , you can only BBQ on the flagstones set into the signposted area</li>
+  <li>six <a href="/c/portal/layout?p_l_id=216028">outdoor exercise stations</a></li>
+  <li><a href="/c/portal/layout?p_l_id=24236">football pitches</a> and changing rooms</li>
+  <li><a href="http://www.avongorge.org.uk/">Avon Gorge</a></li>
+  <li>Clifton Down Camp, an Iron Age hillfort near the Clifton Observatory</li>
+  <li><a href="http://www.cliftonobservatory.com/">Clifton Observatory</a>, camera obscura and cave</li>
+  <li>Roman Road on Durdham Downs</li>
+  <li>parts of The Downs are <a href="https://www.historicengland.org.uk/advice/planning/consents/smc">scheduled ancient monuments</a></li>
+  </ul>
+  <h2>The Downs Committee</h2>
+  <p>This is a group that manages The Downs and makes decisions about the area and events held there. Members are Merchant Venturers, councillors and council officers. You can look at <a href="https://democracy.bristol.gov.uk/ieListMeetings.aspx?CommitteeId=212">agendas, minutes and reports from&nbsp;Downs Commitee meetings</a>.</p>
+  <h2>The Avon Gorge and&nbsp;Downs Wildlife project</h2>
+  <p>This is a group of organisations that support the wildlife in the park and run events and tours. For more information visit the <a href="http://www.avongorge.org.uk/">Avon Gorge and&nbsp;Downs Wildlife Project website</a>.</p>
+  <h2>Community support</h2>
+  <p>The Friends of The Downs and Avon Gorge is a community group that supports the park. For more information or to join visit the <a href="http://www.fodag.org/">Friends of The Downs and Avon Gorge website</a>.</p>
+  <h2>Activities</h2>
+  <h3>Cycling</h3>
+  <p>There is an off-road cycle path from Saville Road to Stoke Road. You can’t cycle on footpaths, woodland and grass areas of The Downs.</p>
+  <h3>Horse riding</h3>
+  <p>You can ride horses around the football pitches except on Sundays and bank holidays. You can’t ride horses on the football areas or the area from Bridge Valley Road to the Clifton Suspension Bridge.</p>
+  <h3>Kite flying</h3>
+  <p>The Downs is exposed, which is good for flying kites.</p>
+  <h3>Outdoor fitness sessions</h3>
+  <p>There are sessions run by:</p>
+  <ul>
+  <li><a href="http://www.calonpersonaltraining.co.uk/group-fitness-classes-bristol.php">Calon Personal Training</a></li>
+  <li><a href="https://www.bemilitaryfit.com/bristol-clifton-downs">British Military Fitness</a></li>
+  </ul>
+  <h3>Nordic walking</h3>
+  <p>Nordic walking is outdoor fitness walking using specially designed poles. Find out about sessions at the Downs at the <a href="http://www.bristolnordicwalking.co.uk/">Bristol Nordic Walking website</a>.</p>
+  <h2>Walking routes</h2>
+  <p>You can download our walking routes:</p>
+  <h3>Bird trail</h3>
+  <p>1.4 miles (1 hour)</p>
+  <p><a href="/documents/20182/32863/The+Downs+Bird+Trail+leaflet/a2651049-3617-4d9a-81f9-38daa432839d" target="_blank">Bird trail leaflet<span class="auto-generated-accessibly-text"> (pdf, 681KB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  <h3>Lichen trail</h3>
+  <p>0.4 miles (30 minutes)</p>
+  <p><a href="/documents/20182/32863/The+Downs+Lichen+Trail+leaflet/452b7e0c-a18d-4357-bc09-695fa328682d" target="_blank">Lichen trail leaflet<span class="auto-generated-accessibly-text"> (pdf, 2.1MB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  <h3>Meadow trail</h3>
+  <p>0.7 miles (30 minutes)</p>
+  <p><a href="/documents/20182/32863/The+Downs+Meadow+trail+leaflet/1a819545-8954-445a-a051-f73049c8c851" target="_blank">Meadow trail leaflet<span class="auto-generated-accessibly-text"> (pdf, 1.8MB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  <h3>Tree trail</h3>
+  <p>1.4 miles (1 hour)</p>
+  <p><a href="/documents/20182/32863/The+Downs+Tree+trail+leaflet/d662a985-bc71-4ad1-8434-4062bf6c3cd4" target="_blank">Tree trail leaflet<span class="auto-generated-accessibly-text"> (pdf, 1.1MB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  <h3>Seasonal family trails</h3>
+  <p><a href="/documents/20182/32863/The+Downs+spring+family+trail/edfd8579-12b9-4af0-89f8-a117d7631766" target="_blank">Spring family trail leaflet<span class="auto-generated-accessibly-text"> (pdf, 1.3MB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> &nbsp;</p>
+  <p><a href="/documents/20182/32863/The+Downs+summer+family+trail/fe83be7b-ff26-4cf6-98fa-552d7ec1618b" target="_blank">Summer family trail leaflet<span class="auto-generated-accessibly-text"> (pdf, 1.7MB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  <p><a href="/documents/20182/32863/The+Downs+autumn+family+trail/28b0d80a-d3b8-490d-845d-ef9626f73c60" target="_blank">Autumn family trail leaflet<span class="auto-generated-accessibly-text"> (pdf, 2MB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  <p><a href="/documents/20182/32863/The+Downs+winter+family+trail/375d4991-12a2-45c2-ad7f-9f9c3394bcf7" target="_blank">Winter family trail leaflet<span class="auto-generated-accessibly-text"> (pdf, 1.3MB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  <h3>History trails</h3>
+  <p><a href="/documents/20182/32863/Durdham+Down+History+Trail/ed1afcb4-a84d-4a11-adb5-e912e47a7b70" target="_blank">Durdham Down history trail leaflet<span class="auto-generated-accessibly-text"> (pdf, 2MB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  <p><a href="/documents/20182/32863/Clifton+Down+History+Trail/f4df2d0b-46aa-49e3-ac96-6cf7eaf14bf1" target="_blank">Clifton Down history trail leaflet<span class="auto-generated-accessibly-text"> (pdf, 1.9MB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  <h2>Wildlife on the Downs</h2>
+  <p><a href="/documents/20182/1359405/Wildlife+on+the+Avon+Gorge+and+Bristol+Downs+leaflet/17a773df-5467-4998-8178-e24e0d572a3f" target="_blank">Bristol Downs wildlife sheet<span class="auto-generated-accessibly-text"> (pdf, 1MB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  <h2>Awards and heritage</h2>
+  <ul>
+  <li>Regionally Important Geological and Geomorphological Site: an important place for geology and geomorphology</li>
+  <li>Site of nature conservation interest: protected area of importance for wildlife</li>
+  <li><a href="http://www.darkskydiscovery.org.uk/">Dark Sky Discovery Site</a>: a good place to look at the night sky</li>
+  </ul>
+</body>
+</html>

--- a/server/data/parkinfo/EASTPK.html
+++ b/server/data/parkinfo/EASTPK.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Eastville Park</title>
+</head>
+<body>
+  <h1>Eastville Park</h1>
+  <p>Victorian city park with children’s playgrounds and green space.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no admission charge. Eastville Park is open at all times.</p>
+  <h2>Location</h2>
+  <p>Eastville Park, Fishponds Road, Eastville, Bristol, BS5</p>
+  <h2>Parking</h2>
+  <p>You can park at Eastville Park car park, at Park Avenue, BS5 6QL.</p>
+  <p>Check signs at the car parks for exact closing time as this changes throughout the year.</p>
+  <h3>Open hours</h3>
+  <p>Monday to Friday: 7.30am to dusk<br/>
+  Saturday to Sunday: 8:30am to dusk</p>
+  <p>Car park closed on 25 December.</p>
+  <h2>Disabled access</h2>
+  <p>To find out about accessibility at Eastville Park, you can look at an <a href="http://www.disabledgo.com/access-guide/bristol-city-council/eastville-park">access guide on DisabledGo</a>.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li><a href="/c/portal/layout?p_l_id=24290">fishing lake</a></li>
+  <li>dog-free playground for under 15s with basketball area</li>
+  <li>play area for under 12s</li>
+  <li>three <a href="/c/portal/layout?p_l_id=24236">football pitches</a></li>
+  <li><a href="/c/portal/layout?p_l_id=24236">tennis court</a></li>
+  <li>one mile running circuit</li>
+  <li><a href="/c/portal/layout?p_l_id=24236">one bowling green</a></li>
+  </ul>
+</body>
+</html>

--- a/server/data/parkinfo/GREVSMPA.html
+++ b/server/data/parkinfo/GREVSMPA.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Greville Smyth Park</title>
+</head>
+<body>
+  <h1>Greville Smyth Park</h1>
+  <p>Local community park in south Bristol with green space and children’s play area.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no admission charge. Greville Smyth Park is open at all times.</p>
+  <h2>Location</h2>
+  <p>Greville Smyth Park, Ashton Road, Ashton, Bristol BS3 2EA</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out where to park in Bristol.</p>
+  <h2>Disabled access</h2>
+  <p>The park is on different levels, so some paths are not suitable for wheelchairs.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>dog-free play area for under 12s</li>
+  <li>dog-free play area for teenagers</li>
+  <li>three <a href="/c/portal/layout?p_l_id=24236">football pitches</a></li>
+  <li>one <a href="/c/portal/layout?p_l_id=24299">ping pong table</a></li>
+  <li>tennis courts managed by <a href="http://www.grevillesmythtennis.co.uk/">Greville Smyth Tennis Club</a></li>
+  <li>five <a href="/c/portal/layout?p_l_id=216028">outdoor exercise stations</a></li>
+  <li>bowling green managed by&nbsp;<a href="http://gscbc.org.uk/">Greville Smyth Community Bowls Club</a></li>
+  </ul>
+  <h2>Activities</h2>
+  <p>There are outdoor fitness sessions run by <a href="http://www.calonpersonaltraining.co.uk/group-fitness-classes-bristol.php">Calon Personal Training</a></p>
+  <h2>Community support</h2>
+  <p>Friends of Greville Smyth (FROGS) is a community group that supports the park. For more information or to join visit <a href="https://friendsofgrevillesmyth.wordpress.com/">the FROGS website</a>.</p>
+</body>
+</html>

--- a/server/data/parkinfo/HENGPA.html
+++ b/server/data/parkinfo/HENGPA.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Blaise Castle Estate</title>
+</head>
+<body>
+  <h1>Hengrove Park</h1>
+  <p>Large open space including a large adventure play park and wheels park for skateboarders and BMX riders.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. Hengrove Park is open at all times.</p>
+  <h3>Hengrove play park</h3>
+  <p>We reserve the right to change these opening times at short notice for reasons like maintenance, weather and staff shortage.</p>
+  <p><strong>Winter opening times: 1 October to 31 March</strong></p>
+  <p>Monday and Tuesdays: closed (except in Bristol school holidays)<br/>
+  Wednesday: 10am to 5pm<br/>
+  Thursday: 10:30am to 5pm<br/>
+  Friday: 10am to &nbsp;5pm<br/>
+  Saturday: 10am to 5pm<br/>
+  Sunday: 10:30am to 5pm</p>
+  <p>Will close at dusk if that’s earlier than 5pm</p>
+  <p><strong>Christmas and new year&nbsp;</strong></p>
+  <p>24 to 26&nbsp;December: closed<br/>
+  31 December to&nbsp;1 January: closed</p>
+  <p><strong>Summer Opening hours: 1 April to 30 September</strong></p>
+  <p>Monday: closed&nbsp;(except bank holidays and in Bristol school holidays)<br/>
+  Tuesday: 10am to 6pm &nbsp;<br/>
+  Wednesday: 10am to 6pm&nbsp;<br/>
+  Thursday: 10:30am to 6pm&nbsp;<br/>
+  Friday: 10am to 6pm&nbsp;<br/>
+  Saturday: 10am to 6pm&nbsp;<br/>
+  Sunday: 10:30am to 6pm&nbsp;</p>
+  <p>Thursday and Sunday the park will open for&nbsp;settling sessions with restricted access from 9:30am to 10:30am.</p>
+  <p><strong>Play park: inclusive settling sessions</strong></p>
+  <p>Times: 9:30am to 10:30am, Thursdays and Sundays</p>
+  <p>Our inclusive settling sessions are for disabled children so they can enjoy all areas of the play park with their siblings and family.</p>
+  <p>To access the site, parent/carers must show their <a href="https://www.bristol.gov.uk/en_US/social-care-health/bristol-register-disabled-children">Bristol Register of Disabled Children Pink Card</a>, or other local equivalent.</p>
+  <h3>Hengrove wheels park</h3>
+  <p>Open at all times.</p>
+  <h2>Location</h2>
+  <p>Hengrove Park, Hengrove Way, Hengrove, Bristol BS14 0HR</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Disabled access</h2>
+  <p>The park is mainly flat with tarmac paths, but Hengrove mounds is hilly and has rough paths and uneven ground.</p>
+  <p>There are accessible toilets at the play park.</p>
+  <p>To find out about accessibility at the play park, you can look at an <a href="http://www.disabledgo.com/access-guide/bristol-city-council/hengrove-play-park">access guide on DisabledGo</a>.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>Café (at the play Park) open Saturday and Sunday 11am to 5pm</li>
+  <li>
+  <p>room available for children’s parities,&nbsp;£15 per hour, contact site office to book</p>
+  </li>
+  <li>toilets with baby change facilities (at the play park)</li>
+  <li>play park (see <a href="/documents/20182/32883/Map%20and%20layout%20of%20Hengrove%20Play%20Park.pdf/94ce5d22-2ca6-4080-9933-7a38d256a7d6" target="_blank">play park map for facilities<span class="auto-generated-accessibly-text"> (pdf, 1.1MB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> )</li>
+  <li>wheels park for skateboards, rollerblades and BMX riders</li>
+  <li>seating areas and picnic areas (not covered)</li>
+  <li>wildlife area at west end of park</li>
+  </ul>
+  <h2>Model aircraft, including drones</h2>
+  <p>Under the <a href="/c/portal/layout?p_l_id=1629977">park byelaws</a>,&nbsp;you can fly model aircraft, including drones, in <a href="/documents/20182/32823/Model+aircraft+Hengrove/6c1463ab-c22d-cefb-d327-af17b84b7193" target="_blank">part of Hengrove Park<span class="auto-generated-accessibly-text"> (pdf, 445KB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> .</p>
+  <p>The model aircraft must weigh 7kg or less, without its fuel. The person flying the aircraft must be a member of the British Model Flying Association and have public liability insurance.</p>
+</body>
+</html>

--- a/server/data/parkinfo/HORFCO.html
+++ b/server/data/parkinfo/HORFCO.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Horfield Common</title>
+</head>
+<body>
+  <h1>Horfield Common</h1>
+  <p>An open space in the quiet suburbs of north Bristol.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. Horfield Common is open at all times.</p>
+  <h2>Location</h2>
+  <p>Horfield Common, Bristol, BS7 0XJ</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Disabled access</h2>
+  <p>Horfield Common is accessible, but there are some gentle slopes.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>community café: find out about <a href="http://friendsofhorfieldcommon.weebly.com/the-cafe-on-the-common.html">the Café on the Common at the Friends of Horfield Common website</a></li>
+  <li>two dog-free play areas</li>
+  <li><a href="/c/portal/layout?p_l_id=24317">tennis courts</a></li>
+  <li><a href="/c/portal/layout?p_l_id=24236">bowling green</a></li>
+  <li>wildlife pond</li>
+  <li>measured routes: marked routes (500m, 1km and 5km) for walking, jogging or running</li>
+  </ul>
+  <p>The tennis centre is&nbsp;closed on:</p>
+  <ul>
+  <li>25, 26, 27 and 31&nbsp;December</li>
+  <li>1&nbsp;January</li>
+  </ul>
+  <h2>Activities</h2>
+  <ul>
+  <li>outdoor fitness sessions run by <a href="http://www.calonpersonaltraining.co.uk/group-fitness-classes-bristol.php">Calon Personal Training</a></li>
+  <li>accessible <a href="http://walkswithwheelchairs.com/UK/Bristol/Bristol/582">walking route for buggies and wheelchairs at Accessible Walks</a></li>
+  </ul>
+  <h2>Community support</h2>
+  <p>Friends of Horfield Common is a community group that support the park. For more information or to join visit the <a href="http://friendsofhorfieldcommon.weebly.com/index.html">Friends of Horfield Common website</a>.</p>
+
+</body>
+</html>

--- a/server/data/parkinfo/KINGWELAM5.html
+++ b/server/data/parkinfo/KINGWELAM5.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Kings Weston Estate</title>
+</head>
+<body>
+  <h1>Kings Weston Estate</h1>
+  <p>A historic landscape covering over 300 acres, with many historic buildings and garden features.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no admission charge for the grounds of the Estate. The grounds are open at all times. Kings Weston House is not open to the public, except for special events. Check the <a href="http://kingswestonhouse.co.uk/">Kings Weston House website</a> for more information.</p>
+  <h2>Location</h2>
+  <p>Kings Weston Estate, Kings Weston Lane, Kingsweston, Bristol BS11 0UR</p>
+  <h2>Parking</h2>
+  <p>There is parking at Shirehampton Car Park off Shirehampton Road.</p>
+  <h2>Disabled access</h2>
+  <p>The Estate has uneven woodland paths that get muddy in wet weather, which means access for wheelchairs and pushchairs may be difficult.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li><a href="http://kingswestonhouse.co.uk/">Kings Weston House</a></li>
+  <li><a href="http://kingswestonhouse.co.uk/cafe/">Hunting Vaults café</a> in Kings Weston House</li>
+  <li>The Brewhouse by Vanbrugh (c1715)</li>
+  <li>The Echo loggia by Vanbrugh (c1715)</li>
+  <li>Banqueting loggia by Vanbrugh (c1718)</li>
+  <li>Penpole Dial, in Penpole Wood on Penpole Point</li>
+  <li>Penpole Wood</li>
+  <li>Penpole Lodge ruins in Penpole Wood</li>
+  </ul>
+  <p>The nearest public toilets are at <a href="/c/portal/layout?p_l_id=217071">Ridingleaze Citizen Service Point</a>.</p>
+  <h2>Community support</h2>
+  <p>The Kings Weston Action Group is a community group that supports the estate. For more information or to join visit the <a href="http://www.kwag.org.uk/">Kings Weston Action Group website</a>.</p>
+  <h2>Events</h2>
+  <p>Kings Weston Action Group holds events throughout the year. See <a href="http://www.kwag.org.uk/about/events-at-kings-weston/">what’s on at the Kings Weston Action Group website</a>.</p>
+  <h2>Awards and heritage</h2>
+  <ul>
+  <li>Regionally Important Geological and Geomorphological Site: an important place for geology and geomorphology</li>
+  <li>site of nature conservation interest: protected area of importance for wildlife</li>
+  </ul>
+</body>
+</html>

--- a/server/data/parkinfo/NETHREGR.html
+++ b/server/data/parkinfo/NETHREGR.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Netham Park</title>
+</head>
+<body>
+  <h1>Netham Park and Pavilion</h1>
+  <p>Large park and green space in East Bristol with leisure, sport and recreation facilities.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. The park is open at all times.</p>
+  <h3>Pavilion opening times:</h3>
+  <ul>
+  <li>Saturday: 1pm to 4pm for pre-booked sports fixtures</li>
+  <li>Sunday: 10am to 1pm for pre-booked sports fixtures</li>
+  </ul>
+  <h2>Location</h2>
+  <p>Netham Park, Avonvale Rd, Netham, Bristol, BS5 9RZ</p>
+  <h2>Parking</h2>
+  <p>There is a dedicated car park off Avonvale Road, Redfield. It is open at all times.</p>
+  <p>There is also a car park by the pavilion, which is only open during sports fixtures and events.</p>
+  <h2>Disabled access</h2>
+  <p>Park access is limited as there are no footpaths around the lower plateau. The Pavilion is fully accessible.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>children’s playground</li>
+  <li><a href="/c/portal/layout?p_l_id=24236">football pitches</a></li>
+  <li><a href="/c/portal/layout?p_l_id=24236">cricket pitch</a>, home to the Bristol Pakistani Cricket Club</li>
+  <li>multi-use games area with floodlights: no booking needed, turn up and play</li>
+  <li>measured route: marked 500m route for walking, jogging or running</li>
+  </ul>
+  <h3>Pavilion facilities:</h3>
+  <ul>
+  <li>changing rooms</li>
+  <li>hot showers for sports teams and officials</li>
+  <li>toilets</li>
+  </ul>
+  <h2>Community support</h2>
+  <p>The Friends of Netham Park is a community group that support the park. For more information on joining the group visit the&nbsp;<a href="https://www.facebook.com/nethamfriends">Friends of Netham Park Facebook page</a>.</p>
+
+</body>
+</html>

--- a/server/data/parkinfo/OLDBCOES.html
+++ b/server/data/parkinfo/OLDBCOES.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Oldbury Court Estate</title>
+</head>
+<body>
+  <h1>Oldbury Court Estate</h1>
+  <p>Parkland with woods, riverside paths, and children’s play park.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. Oldbury Court Estate is open at all times.</p>
+  <h2>Location</h2>
+  <p>Oldbury Court Estate, Oldbury Court Road, Fishponds, Bristol, BS16 2JH</p>
+  <h2>Parking</h2>
+  <p>There are two car parks, which are open from: 8am to dusk (Mon-Fri) and 8:30am to dusk (Sat &amp; Sun).</p>
+  <p>Check signs at the car parks for exact closing time as this changes throughout the year.</p>
+  <ul>
+  <li>OIdbury Court Estate car park: off Oldbury Court, Fishponds, Bristol, BS16 2JH</li>
+  <li>Snuff Mills car park: at the end of River View, Stapleton, Bristol, BS16 1DL</li>
+  </ul>
+  <p>There is no charge for parking.</p>
+  <p>Car parks closed on 25 December.</p>
+  <h2>Disabled access</h2>
+  <p>You can find <a href="http://www.disabledgo.com/access-guide/bristol-city-council/oldbury-court-estate">an access guide on the DisabledGo website</a>.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>café kiosk and terrace seating next to the play park</li>
+  <li>toilets with disabled and baby changing facilities (next to the play area and in the Snuff Mills car park)</li>
+  <li>children’s play park for those 13 and under</li>
+  <li>tea hut at Snuff Mills</li>
+  <li>picnic spots</li>
+  <li><a href="/c/portal/layout?p_l_id=24290">fishing</a> in the River Frome, in areas marked on the path only</li>
+  <li>two <a href="/c/portal/layout?p_l_id=24236">football pitches</a></li>
+  <li>one <a href="/c/portal/layout?p_l_id=24236">cricket pitch</a></li>
+  <li>grassed space for play and sport</li>
+  <li>Snuff Mills park with woodland and riverside walks and community garden</li>
+  </ul>
+  <h2>Activities</h2>
+  <ul>
+  <li>Frome Valley nature trail: get <a href="http://www.fromewalkway.org.uk/walks.html">a leaflet with walks in from the Frome Valley Walkway website</a></li>
+  <li>walking: there is a network of pathways including an orienteering path and the <a href="http://www.fromewalkway.org.uk/">Frome Valley Walkway</a></li>
+  </ul>
+  <h2>Events</h2>
+  <p>The Snuff Mills Action Group holds events throughout the year. See what’s on at <a href="http://snuffmills.blogspot.co.uk/">the Snuff Mills Action Group website</a>.</p>
+  <h2>Café kiosk</h2>
+  <p>Address: Oldbury Court Estate, Fishponds, Bristol BS16 2HH</p>
+  <p>There is outdoor covered seating.&nbsp;</p>
+  <h3>Opening times</h3>
+  <ul>
+  <li>Daily, 9am to 3pm (October to March)</li>
+  <li>Daily, 9am to 5pm (April to September)</li>
+  </ul>
+  <p>Opening times may change depending on the weather.</p>
+  <h2>Awards</h2>
+  <p>Site of nature conservation interest: protected area of importance for wildlife.</p>
+</body>
+</html>

--- a/server/data/parkinfo/QUEESQ.html
+++ b/server/data/parkinfo/QUEESQ.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Queen Square</title>
+</head>
+<body>
+  <h1>Queen Square</h1>
+  <p>Open space with level lawns and wide gravel paths in the centre of Bristol.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no admission charge. Queen Square is open at all times. Access may be restricted during special events.</p>
+  <h2>Location</h2>
+  <p>Queen Square, Bristol BS1 4LH</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Disabled access</h2>
+  <p>You can find <a href="http://www.disabledgo.com/access-guide/bristol-city-council/queen-square">an access guide on the DisabledGo website</a>. You can also look at <a href="http://www.disabledgo.com/access-guide/bristol-city-council/route-plan---queen-square">a route plan on the DisabledGo website</a>.</p>
+  <h2>Community support</h2>
+  <p>The Queen Square Association is a community and local business group that works with us to manage the park. For more information or to join visit <a href="http://www.queensquareassociation.org.uk/index.htm">the Queen Square Association website</a>.</p>
+  <h2>Activities</h2>
+  <p>Queen Square is part of the Bristol City Centre Nature Trail. You can <a href="http://www.avonwildlifetrust.org.uk/sites/default/files/city_centre_nature_trail.pdf">get a guide from the Avon Wildlife Trust website</a>.</p>
+</body>
+</html>

--- a/server/data/parkinfo/REDCPA.html
+++ b/server/data/parkinfo/REDCPA.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Redcatch Park</title>
+</head>
+<body>
+  <h1>Redcatch Park</h1>
+  <p>Neighbourhood park in Knowle with children’s playground, tennis courts and football pitches.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. Redcatch Park is open at all times.</p>
+  <h2>Location</h2>
+  <p>Broadwalk, Bristol, BS4 2RD</p>
+  <h2>Parking</h2>
+  <p>Dedicated car park is open at the following times (7 days a week)</p>
+  <p>7.30am to 4.30pm from 1&nbsp;October to 31&nbsp;&nbsp;March<br/>
+  7.30am to 8pm 1&nbsp;April to 30&nbsp;&nbsp;September&nbsp;<br/>
+  Car park closed on: Christmas Day, Boxing Day and New Year's Day</p>
+  <h2>Disabled access</h2>
+  <p>Entrances are wide enough for wheelchairs.</p>
+  <p>However, access is restricted when the car park is closed, to restrict motorcycle access.&nbsp;Keys can be obtained on request.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>
+  <p>four tennis courts: free for casual use, no booking needed</p>
+  </li>
+  <li>multi-use games area</li>
+  <li>two football pitches (bookable on Saturdays and Sundays)</li>
+  <li>outdoor seating</li>
+  <li>public toilets (same opening times as car park as listed above)</li>
+  <li>measured route: marked 600m route for walking, jogging or running</li>
+  <li>children’s play area</li>
+  <li>shrub beds including herbaceous borders</li>
+  <li>wild flower meadow</li>
+  </ul>
+  <p>Toilets closed on: Christmas Day, Boxing Day and New Year's Day&nbsp;</p>
+  <p>Over the Christmas period the toilets will have shorter opening hours on the days they are in use.&nbsp;</p>
+  <h2>Community support</h2>
+  <p>The Friends of Redcatch&nbsp;Park is a community group that support the park.</p>
+  <p>For more information or to join visit the <a href="http://www.friendsofredcatchpark.com/">Friends of Redcatch Park website</a>.&nbsp;</p>
+</body>
+</html>

--- a/server/data/parkinfo/REDLGRPA.html
+++ b/server/data/parkinfo/REDLGRPA.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Redland Green</title>
+</head>
+<body>
+  <h1>Redland Green</h1>
+  <p>Local park with children’s playground and grassy area.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no admission charge. Redland Green is open at all times.</p>
+  <h2>Location</h2>
+  <p>Redland Green, Redland, Bristol, BS6 7EH</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Disabled access</h2>
+  <p>Redland Green is accessible for wheelchairs.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>children’s playground with equipment for younger children</li>
+  <li>bowling club</li>
+  <li>private tennis club</li>
+  <li>pedestrian and cycling routes connecting Redland Green and Westbury Park</li>
+  </ul>
+  <h2>Community support</h2>
+  <p>The Redland Green Community Group is a group that supports the park. For more information or to join visit <a href="https://sites.google.com/site/redlandgreencommunity/">the Redland Green Community Group website</a>.</p>
+  <h2>Events</h2>
+  <p>The Redland &amp; Cotham Amenities Society (RCAS) holds events throughout the year. See <a href="http://www.rcas.org.uk/">what’s on at the RCAS website</a>.</p>
+</body>
+</html>

--- a/server/data/parkinfo/STAGPA.html
+++ b/server/data/parkinfo/STAGPA.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>St Agnes Park</title>
+</head>
+<body>
+  <h1>St Agnes Park</h1>
+  <p>Popular community park with playground.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. St Agnes Park is open at all times.</p>
+  <h2>Location</h2>
+  <p>St. Agnes Park, Thomas Street, Montpelier, Bristol, BS2 9QJ</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Disabled access</h2>
+  <p>St Agnes Park is accessible for wheelchairs.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>dog-free playground</li>
+  <li>public toilets nearby at Cabot Circus, BS1 3BX</li>
+  </ul>
+  <h2>Community support</h2>
+  <p>St Pauls Unlimited is a community group that supports the park. For more information or to join visit <a href="https://www.facebook.com/St-Pauls-Unity-280889132019146/">the St Pauls Unlimited website</a>.</p>
+</body>
+</html>

--- a/server/data/parkinfo/STANPA.html
+++ b/server/data/parkinfo/STANPA.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>St Andrews Park</title>
+</head>
+<body>
+  <h1>St Andrews Park</h1>
+  <p>Classic Victorian neighbourhood park.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. St Andrews Park is open at all times.</p>
+  <h2>Location</h2>
+  <p>St Andrews Park, Effingham Road, St Andrews, Bristol BS6</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Disabled access</h2>
+  <p>To find out about accessibility at St Andrews Park, you can look at <a href="http://www.disabledgo.com/access-guide/bristol-city-council/st-andrews-park">an access guide on DisabledGo</a>.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>dog-free children’s play area</li>
+  <li>outdoor <a href="/c/portal/layout?p_l_id=24236">bowling green</a> managed by St Andrews and Kildare Bowling Club</li>
+  <li>paddling pool for children (unsupervised), open from the first May bank holiday to September</li>
+  <li>toilets</li>
+  </ul>
+  <h3>Toilet opening hours</h3>
+  <p>Monday to Sunday: 8.15am to 6.15pm</p>
+  <p>Closed: 25 and 26 December and 1 January</p>
+  <h2>Community support</h2>
+  <p>The Friends of St Andrews Park is a community group that supports the park. For more information or to join visit the <a href="http://www.friendsofstandrewspark.com/">Friends of St Andrews Park website</a>.</p>
+  <h2>Events</h2>
+  <p>The Friends of St Andrews Park holds events throughout the year. See <a href="http://friendsofstandrewspark.ning.com/events">what’s on at the Friends of St Andrews Park website</a>.</p>
+</body>
+</html>

--- a/server/data/parkinfo/STGEPA.html
+++ b/server/data/parkinfo/STGEPA.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>St George Park</title>
+</head>
+<body>
+  <h1>St George Park</h1>
+  <p>Large Victorian suburban park.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. St George Park is open at all times.</p>
+  <h2>Location</h2>
+  <p>Church Road, St George, Bristol, BS5 7AA</p>
+  <h2>Parking</h2>
+  <p>You can park for up to three hours in the car park at Chalks Road, St George, BS5 8EN. There is no charge for parking.</p>
+  <h2>Disabled access</h2>
+  <p>St George Park is accessible for wheelchairs.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>dog-free playground</li>
+  <li>lake with ducks and swans</li>
+  <li>large wheels park for BMX, skateboards and scooters</li>
+  <li><a href="/c/portal/layout?p_l_id=24317">tennis courts</a></li>
+  <li><a href="/c/portal/layout?p_l_id=24236">bowling green</a>, where St George Bowling Club&nbsp;and Bristol Omnibus Bowling Club are based</li>
+  <li>original Victorian entrance</li>
+  <li>seasonal attendant</li>
+  <li>café kiosk with outdoor seating area</li>
+  </ul>
+  <h3>Fishing</h3>
+  <p>Under the <a href="/c/portal/layout?p_l_id=1629977">park byelaws</a> you can't fish in St George Park lake. You can fish in and next to all other parks and green spaces, with a line or net.</p>
+  <h2>Community support</h2>
+  <p>The Friends of St George Park is a community group that supports the park. For more information or to join visit the <a href="https://www.facebook.com/FriendsOfStGeorgePark">Friends of St George Park Facebook page</a> or contact them at <a href="mailto:fosgpg@yahoo.co.uk%20">fosgpg@yahoo.co.uk</a>.&nbsp;</p>
+</body>
+</html>

--- a/server/data/parkinfo/STOKPAES.html
+++ b/server/data/parkinfo/STOKPAES.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Stoke Park Estate</title>
+</head>
+<body>
+  <h1>Stoke Park Estate</h1>
+  <p>Historic park and garden alongside the M32.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. Stoke Park Estate is open at all times.</p>
+  <h2>Location</h2>
+  <p>Stoke Park Estate, Duchess Gate, Park Road, Stapleton, Bristol BS16 1AU</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Disabled access</h2>
+  <p>To find out about accessibility at Stoke Park Estate, you can look at <a href="http://www.disabledgo.com/access-guide/bristol-city-council/stoke-park-estate">an access guide on DisabledGo</a>.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>dew pond at the base of the northern slope</li>
+  <li><a href="/c/portal/layout?p_l_id=24290">fishing lake</a>, also known as Duchess pond</li>
+  <li>Hermitage Tunnel (Grade II listed)</li>
+  <li>Purdown BT Tower</li>
+  <li>the yellow Dower House, built in 1563 as a private stately home, but is now converted to private flats</li>
+  <li>woodland areas and trees</li>
+  <li>the nearest public toilet is at Snuff Mills Park, five to ten minutes walk away from the Duchess entrance on Park Road</li>
+  <li>Purdown Percy, a World War 2 anti-aircraft battery (<a href="https://www.historicengland.org.uk/advice/planning/consents/smc">scheduled&nbsp;monument</a>)</li>
+  </ul>
+  <h2>Community support</h2>
+  <p>Stoke Park Estate has a community group which supports the estate. To find out more visit the <a href="https://www.facebook.com/friendsofstokepark/">Friends of Stoke Park Facebook page</a>.</p>
+  <h2>Activities</h2>
+  <p>You can follow one of our three walks:</p>
+  <ul>
+  <li><a href="/documents/20182/32879/Stoke+Park+Walk.pdf/7543b91f-dfa0-4402-a6a9-1f93a9a48df4" target="_blank">Stoke Park Walk<span class="auto-generated-accessibly-text"> (pdf, 200KB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </li>
+  <li><a href="/documents/20182/32879/Barn+Wood+Walk.pdf/f6961a7d-8f9a-4caa-bbd8-69a945f11402" target="_blank">Barn Wood Walk<span class="auto-generated-accessibly-text"> (pdf, 216KB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </li>
+  <li><a href="/documents/20182/32879/Hermitage+Walk.pdf/5d042f68-e99b-45a0-84a2-23da6bdc3c3e" target="_blank">Hermitage Walk<span class="auto-generated-accessibly-text"> (pdf, 211KB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> &nbsp;</li>
+  <li><a href="/documents/20182/32879/Stoke+Park+Trail+Map/287a6cf9-97e3-4ec6-b239-b5a334674b44" target="_blank">Stoke Park trail map<span class="auto-generated-accessibly-text"> (pdf, 3.7MB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </li>
+  <li>
+  <p><a href="/documents/20182/32879/Stoke+Park+Activity+Sheet/bff7b20f-f1e0-457c-ac64-a21730fc7032" target="_blank">Stoke Park activity sheet<span class="auto-generated-accessibly-text"> (pdf, 5.5MB) <span class="icon icon--bcc icon--bcc--externallink"></span><span class="accessibly-hidden">(opens new window)</span></span></a> </p>
+  </li>
+  </ul>
+  <h2>Restoration works</h2>
+  <p><strong>Advice for visitors</strong></p>
+  <p>There will be some disruption to walking routes from&nbsp;October 2018 to March 2019 .</p>
+  <p>This is because of&nbsp;scrub removal and tree-thinning work in the areas below and between Pale Plantation and Barnwood.</p>
+  <p>We advise you to:</p>
+  <ul>
+  <li>check what areas of the park are open or closed</li>
+  <li>plan your walks around the park as layouts will change over time</li>
+  <li>keep dogs under control or&nbsp;on leads</li>
+  </ul>
+  <p>For more information see our <a href="https://www.bristol.gov.uk/stoke-park-restoration-works">Stoke Park restoration works page</a>.</p>
+  <p>If you've any queries email <a href="mailto:Stoke.Park@bristol.gov.uk">Stoke.Park@bristol.gov.uk</a>.</p>
+  <p>The works contractor will also be available to provide information and answer queries.</p>
+  <h2>Awards and heritage</h2>
+  <ul>
+  <li>Regionally Important Geological and Geomorphological Site: an important place for geology and geomorphology</li>
+  <li>Site of nature conservation interest: protected area of importance for wildlife</li>
+  </ul>
+</body>
+</html>

--- a/server/data/parkinfo/STPACHSO.html
+++ b/server/data/parkinfo/STPACHSO.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>St Paul's Park</title>
+</head>
+<body>
+  <h1>St Paul's Park</h1>
+  <p>Small park in the city.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. St Paul’s Park is open at all times.</p>
+  <h2>Location</h2>
+  <p>St Paul’s Park, Portland Square, St Pauls, Bristol BS2 8SA</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>playground and seating within a fenced area</li>
+  <li>basketball hoop</li>
+  <li>climbing wall</li>
+  <li>'twin-fly' play equipment</li>
+  <li>ramp and dish feature for bikes and skateboards</li>
+  <li>grassed event space</li>
+  </ul>
+</body>
+</html>

--- a/server/data/parkinfo/VICTPA.html
+++ b/server/data/parkinfo/VICTPA.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Victoria Park</title>
+</head>
+<body>
+  <h1>Victoria Park</h1>
+  <p>Large Victorian park with children’s play area and grassy space.</p>
+  <h2>Admission and opening times</h2>
+  <p>There is no charge for admission. Victoria Park is open at all times.</p>
+  <h2>Location</h2>
+  <p>Hill Avenue, Bedminster, Bristol BS3</p>
+  <h2>Parking</h2>
+  <p>There is no dedicated car park. Find out <a href="/c/portal/layout?p_l_id=22025">where to park in Bristol</a>.</p>
+  <h2>Disabled access</h2>
+  <p>The park is very hilly. If you have a disability or use a wheelchair you may find it challenging.</p>
+  <h2>Facilities and features</h2>
+  <ul>
+  <li>toilets</li>
+  <li>café: see <a href="https://www.facebook.com/pages/Mrs-Browns-Cafe/127595017311698">Mrs Brown’s Café Facebook page</a> for opening times</li>
+  <li>play area for under 12s at Fraser Street</li>
+  <li>play area at St Lukes Road with five-a-side area</li>
+  <li>play area at Nutgrove Avenue</li>
+  <li><a href="/c/portal/layout?p_l_id=24317">tennis courts</a></li>
+  <li><a href="/c/portal/layout?p_l_id=24236">bowling green</a></li>
+  <li><a href="/c/portal/layout?p_l_id=216055">measured route</a>: marked 1700m route for walking, jogging or running</li>
+  </ul>
+  <h3>Toilet opening times</h3>
+  <p>7.30am to 4pm all year</p>
+  <p>Closed: 25 and&nbsp;&nbsp;26&nbsp;December and 1&nbsp;January</p>
+  <h3>Activities</h3>
+  <ul>
+  <li>Tai Chi run by <a href="http://www.bristoltaichi.com/taichipark.htm">Bristol School of Tai Chi</a></li>
+  <li>outdoor fitness sessions run by <a href="http://www.calonpersonaltraining.co.uk/group-fitness-classes-bristol.php">Calon Personal Training</a></li>
+  <li>outdoor fitness sessions run by <a href="https://www.britmilfit.com/where-we-train/search-results/Bristol/">British Military Fitness</a></li>
+  </ul>
+  <h2>Community support</h2>
+  <p>The Victoria Park Action Group is a community group that supports the park. For more information or join visit the <a href="http://www.vpag.org.uk/">Victoria Park Action Group website</a>.</p>
+</body>
+</html>

--- a/server/tests/.cache/v/cache/lastfailed
+++ b/server/tests/.cache/v/cache/lastfailed
@@ -1,0 +1,5 @@
+{
+  "test_app.py::test_client_get_nearest_parks": true,
+  "test_app.py::test_client_get_park": true,
+  "test_app.py::test_get_all_park_names": true
+}

--- a/server/tests/.cache/v/cache/lastfailed
+++ b/server/tests/.cache/v/cache/lastfailed
@@ -1,5 +1,1 @@
-{
-  "test_app.py::test_client_get_nearest_parks": true,
-  "test_app.py::test_client_get_park": true,
-  "test_app.py::test_get_all_park_names": true
-}
+{}

--- a/server/tests/.cache/v/cache/lastfailed
+++ b/server/tests/.cache/v/cache/lastfailed
@@ -1,3 +1,1 @@
-{
-  "test_app.py::test_client_get_nearest_parks": true
-}
+{}

--- a/server/tests/.cache/v/cache/lastfailed
+++ b/server/tests/.cache/v/cache/lastfailed
@@ -1,1 +1,3 @@
-{}
+{
+  "test_app.py::test_client_get_nearest_parks": true
+}

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -37,7 +37,7 @@ def test_get_all_park_names(client):
 def test_client_get_park(client):
     js = client.get('/api/v1/parks/VICTPA')
     data = json.loads(js.data)
-    assert 'Victoria Park' == data[0]['siteName']
+    assert 'Victoria Park' == data['siteName']
 
 
 def test_client_get_nearest_parks(client):

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -61,7 +61,7 @@ def test_client_get_trees_by_species(client):
 def test_client_get_trees_by_location(client):
     js = client.get('/api/v1/trees/lat=51.44&lng=-2.587&radius=500')
     data = json.loads(js.data)
-    assert len(data) == 10
+    assert len(data) == 836
 
 
 def test_client_get_benches(client):

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -64,6 +64,12 @@ def test_client_get_trees_by_location(client):
     assert len(data) == 836
 
 
+def test_client_get_tree_by_id(client):
+    js = client.get('/api/v1/tree/an1')
+    data = json.loads(js.data)
+    assert data == {'error': 'Not found'}
+
+
 def test_client_get_benches(client):
     js = client.get('/api/v1/benches/lat=51.44&lng=-2.587&radius=500')
     data = json.loads(js.data)

--- a/server/triffidsapi/api.py
+++ b/server/triffidsapi/api.py
@@ -24,7 +24,7 @@ def index():
 def getAllParkNames():
     page = request.args.get('page') or 1
     response = parks.getAllParkNames(int(page))
-    if len(response) == 0:
+    if not response:
         abort(404)
     return jsonify(response)
 
@@ -32,7 +32,7 @@ def getAllParkNames():
 @api.route('/parks/<string:parkCode>', methods=['GET'])
 def getPark(parkCode):
     response = parks.getPark(parkCode)
-    if len(response) == 0:
+    if not response:
         abort(404)
     return jsonify(response)
 
@@ -40,7 +40,7 @@ def getPark(parkCode):
 @api.route('/parks/lat=<string:lat>&lng=<string:lng>&radius=<string:radius>', methods=['GET'])
 def getNearestParks(lat, lng, radius):
     response = parks.getNearestParks(lat, lng, radius)
-    if len(response) == 0:
+    if not response:
         abort(404)
     return jsonify(response)
 
@@ -48,8 +48,7 @@ def getNearestParks(lat, lng, radius):
 @api.route('/tree/<string:treeId>', methods=['GET'])
 def getTree(treeId):
     response = trees.getTreeById(treeId)
-
-    if len(response) == 0:
+    if not response:
         abort(404)
     return jsonify(response)
 
@@ -64,7 +63,7 @@ def getTrees(parkCode):
     else:
         response = trees.getTreesBySpecies(parkCode, latinCode)
 
-    if len(response) == 0:
+    if not response:
         abort(404)
     return jsonify(response)
 
@@ -72,7 +71,7 @@ def getTrees(parkCode):
 @api.route('/trees/lat=<string:lat>&lng=<string:lng>&radius=<string:radius>', methods=['GET'])
 def getTreesByLocation(lat, lng, radius):
     response = trees.getTreesByLocation(lat, lng, radius)
-    if len(response) == 0:
+    if not response:
         abort(404)
     return jsonify(response)
 
@@ -80,6 +79,6 @@ def getTreesByLocation(lat, lng, radius):
 @api.route('/benches/lat=<string:lat>&lng=<string:lng>&radius=<string:radius>', methods=['GET'])
 def getBenches(lat, lng, radius):
     response = benches.getBenches(lat, lng, radius)
-    if len(response) == 0:
+    if not response:
         abort(404)
     return jsonify(response)

--- a/server/triffidsapi/api.py
+++ b/server/triffidsapi/api.py
@@ -45,6 +45,14 @@ def getNearestParks(lat, lng, radius):
     return jsonify(response)
 
 
+@api.route('/parks/info/<string:parkCode>', methods=['GET'])
+def getParkInfo(parkCode):
+    response = parks.getParkInfo(parkCode)
+    if not response:
+        abort(404)
+    return response
+
+
 @api.route('/tree/<string:treeId>', methods=['GET'])
 def getTree(treeId):
     response = trees.getTreeById(treeId)

--- a/server/triffidsapi/parks.py
+++ b/server/triffidsapi/parks.py
@@ -17,29 +17,32 @@ with open(baseDirectory + '/data/parks-and-greens-spaces.json') as json_file:
 
 def getPark(code):
     # Example 'code' CUMBBASO
-    park = []
-    for record in data:
-        parkData = record['fields']
-        site_code = parkData['site_code']
+    url = 'https://opendata.bristol.gov.uk/api/records/1.0/search/'
+    dataset = '?dataset=parks-and-greens-spaces'
+    query = '&q=site_code%3A+' + str(code)
 
-        if (site_code == code):
-            total_trees = trees.getTotalNumbTreesByPark(parkData['site_code'])
-            unique_trees = trees.getNumbUniqueSpeciesByPark(parkData['site_code'])
+    response = requests.get(url + dataset + query)
+    response = response.json()
 
-            park.append({
-                'id': str(parkData['site_code']),
-                'siteName': str(parkData['site_name']),
-                'unique_trees': str(unique_trees),
-                'total_trees': str(total_trees),
-                'lat': parkData['geo_point_2d'][0],
-                'lng': parkData['geo_point_2d'][1],
-                'geoShape': parkData['geo_shape']
-            })
-            print(park)
-            return park
+    if response:
+        parkData = response['records'][0]['fields']
+    else:
+        return []
 
-    print('Park not found')
-    return 0
+    total_trees = trees.getTotalNumbTreesByPark(parkData['site_code'])
+    unique_trees = trees.getNumbUniqueSpeciesByPark(parkData['site_code'])
+
+    park = {
+        'id': str(parkData['site_code']),
+        'siteName': str(parkData['site_name']),
+        'unique_trees': str(unique_trees),
+        'total_trees': str(total_trees),
+        'lat': parkData['geo_point_2d'][0],
+        'lng': parkData['geo_point_2d'][1],
+        'geoShape': parkData['geo_shape']
+    }
+
+    return park
 
 
 def getAllParkNames(page):
@@ -62,7 +65,10 @@ def getAllParkNames(page):
             'total_trees': str(total_trees)
         })
 
-    return parkNames
+    if parkNames:
+        return parkNames
+    else:
+        return []
 
 
 def getNearestParks(lat, lng, radius):
@@ -98,14 +104,16 @@ def getNearestParks(lat, lng, radius):
             'uniqueSpecies': uniqueSpecies
         })
 
-    # print(parks)
-    return parks
+    if parks:
+        return parks
+    else:
+        return []
 
     # Data required
     # site_name, site_code, lat, long, dist, noOfTrees, uniqueSpecies
 
 # getPark('CUMBBASO')
 
-print(getNearestParks(51.439413, -2.589423, 150))
+# print(getNearestParks(51.439413, -2.589423, 150))
 
 # (getAllParkNames(1))

--- a/server/triffidsapi/parks.py
+++ b/server/triffidsapi/parks.py
@@ -123,8 +123,23 @@ def getNearestParks(lat, lng, radius):
     # Data required
     # site_name, site_code, lat, long, dist, noOfTrees, uniqueSpecies
 
+
+def getParkInfo(parkCode):
+
+    targetFilePath = baseDirectory + '/data/parkinfo/' + str(parkCode) + '.html'
+    defaultFilePath = baseDirectory + '/data/parkinfo/' + 'DEFAULT.html'
+
+    if os.path.isfile(targetFilePath):
+        data = open(targetFilePath, 'r')
+    else:
+        data = open(defaultFilePath, 'r')
+
+    return data
+
 # getPark('CUMBBASO')
 
 # print(getNearestParks(51.439413, -2.589423, 150))
 
 # (getAllParkNames(1))
+
+getParkInfo('VICTKPA')

--- a/server/triffidsapi/parks.py
+++ b/server/triffidsapi/parks.py
@@ -24,8 +24,13 @@ def getPark(code):
 
         if (site_code == code):
             total_trees = trees.getTotalNumbTreesByPark(parkData['site_code'])
-            unique_trees = trees.getNumbUniqueSpeciesByPark(
-                parkData['site_code'])
+            unique_trees = trees.getUniqueSpecies(parkData['site_code'])
+
+            if unique_trees:
+                unique_trees = len(unique_trees)
+            else:
+                unique_trees = 0
+
             park.append({
                 'id': str(parkData['site_code']),
                 'siteName': str(parkData['site_name']),
@@ -116,6 +121,6 @@ def getNearestParks(lat, lng, radius):
 
 # getPark('CUMBBASO')
 
-# getNearestParks(51.439413, -2.589423, 150)
+print(getNearestParks(51.439413, -2.589423, 150))
 
 # (getAllParkNames(1))

--- a/server/triffidsapi/parks.py
+++ b/server/triffidsapi/parks.py
@@ -1,7 +1,12 @@
 import json
 import requests
 import os
-from . import trees
+
+if __name__ == '__main__':
+    import trees
+else:
+    from . import trees
+
 
 # Read parks json
 baseDirectory = os.path.join(os.path.dirname(__file__), '..')
@@ -78,10 +83,20 @@ def getNearestParks(lat, lng, radius):
         parkCode = str(record['fields']['site_code'])
 
         # Get number of trees in park
-        totalTrees = len(trees.getTreesByPark(parkCode))
+        totalTrees = trees.getTreesByPark(parkCode)
+
+        if totalTrees:
+            totalTrees = len(totalTrees)
+        else:
+            totalTrees = 0
 
         # Get number of unique species in park
-        uniqueSpecies = len(trees.getUniqueSpecies(parkCode))
+        uniqueSpecies = trees.getUniqueSpecies(parkCode)
+
+        if uniqueSpecies:
+            uniqueSpecies = len(uniqueSpecies)
+        else:
+            uniqueSpecies = 0
 
         parks.append({
             'id': parkCode,
@@ -93,7 +108,7 @@ def getNearestParks(lat, lng, radius):
             'uniqueSpecies': uniqueSpecies
         })
 
-    print(parks)
+    # print(parks)
     return parks
 
     # Data required
@@ -102,3 +117,5 @@ def getNearestParks(lat, lng, radius):
 # getPark('CUMBBASO')
 
 # getNearestParks(51.439413, -2.589423, 150)
+
+# (getAllParkNames(1))

--- a/server/triffidsapi/parks.py
+++ b/server/triffidsapi/parks.py
@@ -24,12 +24,7 @@ def getPark(code):
 
         if (site_code == code):
             total_trees = trees.getTotalNumbTreesByPark(parkData['site_code'])
-            unique_trees = trees.getUniqueSpecies(parkData['site_code'])
-
-            if unique_trees:
-                unique_trees = len(unique_trees)
-            else:
-                unique_trees = 0
+            unique_trees = trees.getNumbUniqueSpeciesByPark(parkData['site_code'])
 
             park.append({
                 'id': str(parkData['site_code']),

--- a/server/triffidsapi/parks.py
+++ b/server/triffidsapi/parks.py
@@ -83,20 +83,10 @@ def getNearestParks(lat, lng, radius):
         parkCode = str(record['fields']['site_code'])
 
         # Get number of trees in park
-        totalTrees = trees.getTreesByPark(parkCode)
-
-        if totalTrees:
-            totalTrees = len(totalTrees)
-        else:
-            totalTrees = 0
+        totalTrees = trees.getTotalNumbTreesByPark(parkCode)
 
         # Get number of unique species in park
-        uniqueSpecies = trees.getUniqueSpecies(parkCode)
-
-        if uniqueSpecies:
-            uniqueSpecies = len(uniqueSpecies)
-        else:
-            uniqueSpecies = 0
+        uniqueSpecies = trees.getNumbUniqueSpeciesByPark(parkCode)
 
         parks.append({
             'id': parkCode,

--- a/server/triffidsapi/parks.py
+++ b/server/triffidsapi/parks.py
@@ -30,6 +30,10 @@ def getPark(code):
         return []
 
     total_trees = trees.getTotalNumbTreesByPark(parkData['site_code'])
+
+    if total_trees == 0:
+        return []
+
     unique_trees = trees.getNumbUniqueSpeciesByPark(parkData['site_code'])
 
     park = {
@@ -56,6 +60,10 @@ def getAllParkNames(page):
             continue
         parkData = record['fields']
         total_trees = trees.getTotalNumbTreesByPark(parkData['site_code'])
+
+        if total_trees == 0:
+            continue
+
         unique_trees = trees.getNumbUniqueSpeciesByPark(parkData['site_code'])
 
         parkNames.append({
@@ -91,6 +99,9 @@ def getNearestParks(lat, lng, radius):
         # Get number of trees in park
         totalTrees = trees.getTotalNumbTreesByPark(parkCode)
 
+        if totalTrees == 0:
+            continue
+            
         # Get number of unique species in park
         uniqueSpecies = trees.getNumbUniqueSpeciesByPark(parkCode)
 

--- a/server/triffidsapi/trees.py
+++ b/server/triffidsapi/trees.py
@@ -21,6 +21,10 @@ def getTreeById(id):
 
     if data:
         return data[0]
+    else:
+        return []
+
+
 
 
 def getTreesByPark(parkCode):
@@ -32,6 +36,8 @@ def getTreesByPark(parkCode):
 
     if data:
         return data
+    else:
+        return []
 
 
 def getTotalNumbTreesByPark(parkCode):
@@ -41,7 +47,7 @@ def getTotalNumbTreesByPark(parkCode):
     if trees:
         return len(trees)
     else:
-        return 0
+        return []
 
 
 def getTreesBySpecies(parkCode, latinCode):
@@ -54,6 +60,8 @@ def getTreesBySpecies(parkCode, latinCode):
 
     if data:
         return data
+    else:
+        return []
 
 
 def getNumbUniqueSpeciesByPark(parkCode):
@@ -67,7 +75,7 @@ def getNumbUniqueSpeciesByPark(parkCode):
         for tree in trees:
             species.append(tree['fields']['latin_code'])
     else:
-        return 0
+        return []
 
     # Convert list to set to get all unique instances of species
     species = set(species)
@@ -88,7 +96,10 @@ def getTreesByLocation(lat, lng, radius):
         treeData = record['fields']
         trees.append(treeData)
 
-    return trees
+    if trees:
+        return trees
+    else:
+        return []
 
 
 def getUniqueSpecies(parkCode):
@@ -102,7 +113,7 @@ def getUniqueSpecies(parkCode):
         for tree in trees:
             species.append(tree['fields']['latin_code'])
     else:
-        return 0
+        return []
 
     # Convert list to set to get all unique instances of species
     species = set(species)

--- a/server/triffidsapi/trees.py
+++ b/server/triffidsapi/trees.py
@@ -71,7 +71,7 @@ def getNumbUniqueSpeciesByPark(parkCode):
 def getTreesByLocation(lat, lng, radius):
     trees = []
 
-    query = "&geofilter.distance=" + str(lat) + "%2C+" + str(lng) + "%2C+" + str(radius) + "&rows=20"
+    query = "&geofilter.distance=" + str(lat) + "%2C+" + str(lng) + "%2C+" + str(radius) + "&rows=1000"
 
     response = requests.get(url + query)
     response = response.json()

--- a/server/triffidsapi/trees.py
+++ b/server/triffidsapi/trees.py
@@ -25,8 +25,6 @@ def getTreeById(id):
         return []
 
 
-
-
 def getTreesByPark(parkCode):
     query = "&q=site_code%3D" + str(parkCode) + "&rows=1000" + "&facet=feature_type_name&facet=common_name"
 

--- a/server/triffidsapi/trees.py
+++ b/server/triffidsapi/trees.py
@@ -37,7 +37,11 @@ def getTreesByPark(parkCode):
 def getTotalNumbTreesByPark(parkCode):
     trees = getTreesByPark(parkCode)
 
-    return len(trees)
+    # Catch none as 0
+    if trees:
+        return len(trees)
+    else:
+        return 0
 
 
 def getTreesBySpecies(parkCode, latinCode):
@@ -59,8 +63,11 @@ def getNumbUniqueSpeciesByPark(parkCode):
     species = []
 
     # Extract species of every tree in park
-    for tree in trees:
-        species.append(tree['latin_code'])
+    if trees:
+        for tree in trees:
+            species.append(tree['fields']['latin_code'])
+    else:
+        return 0
 
     # Convert list to set to get all unique instances of species
     species = set(species)
@@ -91,13 +98,15 @@ def getUniqueSpecies(parkCode):
     species = []
 
     # Extract species of every tree in park
-    for tree in trees:
-        species.append(tree['fields']['latin_code'])
+    if trees:
+        for tree in trees:
+            species.append(tree['fields']['latin_code'])
+    else:
+        return 0
 
     # Convert list to set to get all unique instances of species
     species = set(species)
     return species
-
 
 # print(getTreesByPark("VICTPA"))
 

--- a/server/triffidsapi/trees.py
+++ b/server/triffidsapi/trees.py
@@ -47,7 +47,7 @@ def getTotalNumbTreesByPark(parkCode):
     if trees:
         return len(trees)
     else:
-        return []
+        return 0
 
 
 def getTreesBySpecies(parkCode, latinCode):
@@ -75,7 +75,7 @@ def getNumbUniqueSpeciesByPark(parkCode):
         for tree in trees:
             species.append(tree['fields']['latin_code'])
     else:
-        return []
+        return 0
 
     # Convert list to set to get all unique instances of species
     species = set(species)

--- a/server/triffidsapi/trees.py
+++ b/server/triffidsapi/trees.py
@@ -8,14 +8,14 @@ baseDirectory = os.path.join(os.path.dirname(__file__), '..')
 with open(baseDirectory + '/data/trees.json') as json_file:
     data = json.load(json_file)
 
+url = "https://opendata.bristol.gov.uk/api/records/1.0/search/?dataset=trees"
+
 
 def getTreeById(id):
+    query = "&q=recordid%3D" + str(id) + \
+            "&facet=feature_type_name&facet=common_name&refine.feature_type_name=Tree+-+Parks+and+Green+Space"
 
-    url = "https://opendata.bristol.gov.uk/api/records/1.0/search/"
-    dataset = "?dataset=trees"
-    geofilter = "&q=recordid%3D" + str(id) + "&facet=feature_type_name&facet=common_name&refine.feature_type_name=Tree+-+Parks+and+Green+Space"
-
-    response = requests.get(url + dataset + geofilter)
+    response = requests.get(url + query)
     response = response.json()
     data = response['records']
 
@@ -24,46 +24,35 @@ def getTreeById(id):
 
 
 def getTreesByPark(parkCode):
-    trees = []
+    query = "&q=site_code%3D" + str(parkCode) + "&rows=1000" + "&facet=feature_type_name&facet=common_name"
 
-    # Search for trees by park
-    for record in data:
+    response = requests.get(url + query)
+    response = response.json()
+    data = response['records']
 
-        id = record['recordid']
-        treeData = record['fields']
+    if data:
+        return data
 
-        if parkCode == treeData['site_code']:
-            treeData['id'] = id
-            trees.append(treeData)
-
-    return trees
 
 def getTotalNumbTreesByPark(parkCode):
-    trees = 0
-    for record in data:
-        treeData = record['fields']
-        if parkCode == treeData['site_code']:
-            trees = trees + 1
+    trees = getTreesByPark(parkCode)
 
-    return trees
+    return len(trees)
+
 
 def getTreesBySpecies(parkCode, latinCode):
-    trees = []
+    query = "&q=site_code%3D" + str(parkCode) + "%2C+latin_code%3D" + str(latinCode) + \
+            "&rows=1000&facet=feature_type_name&facet=common_name"
 
-    # Search for trees by park
-    for record in data:
+    response = requests.get(url + query)
+    response = response.json()
+    data = response['records']
 
-        treeData = record['fields']
+    if data:
+        return data
 
-        if parkCode == treeData['site_code'] and latinCode == treeData['latin_code']:
-            trees.append(treeData)
-
-    print(trees)
-    print(len(trees))
-    return trees
 
 def getNumbUniqueSpeciesByPark(parkCode):
-
     # Get all trees within park
     trees = getTreesByPark(parkCode)
 
@@ -82,11 +71,9 @@ def getNumbUniqueSpeciesByPark(parkCode):
 def getTreesByLocation(lat, lng, radius):
     trees = []
 
-    url = "https://opendata.bristol.gov.uk/api/records/1.0/search/"
-    dataset = "?dataset=trees"
-    geofilter = "&geofilter.distance=" + str(lat) + "%2C+" + str(lng) + "%2C+" + str(radius)
+    query = "&geofilter.distance=" + str(lat) + "%2C+" + str(lng) + "%2C+" + str(radius) + "&rows=20"
 
-    response = requests.get(url + dataset + geofilter)
+    response = requests.get(url + query)
     response = response.json()
     data = response['records']
 
@@ -94,13 +81,10 @@ def getTreesByLocation(lat, lng, radius):
         treeData = record['fields']
         trees.append(treeData)
 
-    print(trees)
-    print(len(trees))
     return trees
 
 
 def getUniqueSpecies(parkCode):
-
     # Get all trees within park
     trees = getTreesByPark(parkCode)
 
@@ -108,18 +92,19 @@ def getUniqueSpecies(parkCode):
 
     # Extract species of every tree in park
     for tree in trees:
-        species.append(tree['latin_code'])
+        species.append(tree['fields']['latin_code'])
 
     # Convert list to set to get all unique instances of species
     species = set(species)
-    print(species)
     return species
 
 
-# getTreesByPark("VICTPA")
+# print(getTreesByPark("VICTPA"))
 
 # getTreesBySpecies('VICTPA', 'QURO')
 
 # getTreesByLocation(51.44, -2.587, 500)
 
-# getUniqueSpecies('VICTPA')
+# print(getUniqueSpecies('VICTPA'))
+
+# print(getTotalNumbTreesByPark('VICTPA'))


### PR DESCRIPTION
- Converted data pull from local json to pulling from Open Data API

- Filtering out parks with 0 trees (Closed #52)

- Explicitly asking the API for a hard-coded upper bound of 1000 records, as the API returns only 10 records by default otherwise. `get_trees_by_location` test has been changed to assert the actual number of trees (836) instead of 10

- Error handling changed to catch NoneType returns